### PR TITLE
Fix build on Windows (msvc)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -102,7 +102,7 @@ fn main() -> Result<()> {
                 
                 // msvc tools require /bigobj
                 if target.contains("msvc") {
-                    command.arg("-fPIC,/bigobj");
+                    command.arg("/bigobj");
                 } else {
                     command.arg("-fPIC");
                 }

--- a/build.rs
+++ b/build.rs
@@ -79,6 +79,9 @@ fn main() -> Result<()> {
     } else {
         true
     };
+
+    let target = std::env::var("TARGET").expect("The 'TARGET' environment variable MUST be set");
+
     if should_compile {
         cu_files
             .par_iter()
@@ -95,6 +98,15 @@ fn main() -> Result<()> {
                     .arg("-U__CUDA_NO_BFLOAT162_CONVERSIONS__")
                     .arg(format!("--gpu-architecture=sm_{compute_cap}"))
                     .arg("-c")
+                    .arg("--compiler-options");
+                
+                // msvc tools require /bigobj
+                if target.contains("msvc") {
+                    command.arg("-fPIC,/bigobj");
+                } else {
+                    command.arg("-fPIC");
+                }
+                command
                     .args(["-o", obj_file.to_str().unwrap()])
                     .args(["--default-stream", "per-thread"])
                     .arg("--expt-relaxed-constexpr")
@@ -144,7 +156,9 @@ fn main() -> Result<()> {
     println!("cargo:rustc-link-search={}", build_dir.display());
     println!("cargo:rustc-link-lib=layernorm");
     println!("cargo:rustc-link-lib=dylib=cudart");
-    println!("cargo:rustc-link-lib=dylib=stdc++");
+    if !target.contains("msvc") {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Fixes build on Windows using msvc tools:

1.  Fixes fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
>C:\Users\ADMINI~1\AppData\Local\Temp\2\tmpxft_00001eac_00000000-10_ln_api.cudafe1.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

1. Fixes stdc++ link error, msvc does not support and require `stdc++`, [example](https://github.com/spiceai/mistral.rs/blob/bea876ce81c61f881788c2ab9e2d3dc1dda9fe1e/mistralrs-core/build.rs#L49) 

**Note:** as there is the following PR open, I've included those changes as they will conflict. This should be re-based on top of it or could be merged instead of it as it includes that changes as well (title and description must be updated in this case to mention additional changes) 
https://github.com/huggingface/candle-layer-norm/pull/1